### PR TITLE
Add example WhatsApp and email workflows

### DIFF
--- a/docs/_workflows/email/weekly_report_email.json
+++ b/docs/_workflows/email/weekly_report_email.json
@@ -1,0 +1,127 @@
+{
+  "name": "Envio de Email Semanal",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 9 * * 1"
+            }
+          ]
+        }
+      },
+      "id": "1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6",
+      "name": "Cron Trigger",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [
+        240,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Configurar dados do email\nconst emailData = {\n  destinatario: process.env.REPORT_EMAIL,\n  assunto: 'Relat\u00f3rio Semanal - ' + new Date().toLocaleDateString('pt-BR'),\n  corpo: `\n    <h2>Relat\u00f3rio Semanal</h2>\n    <p>Ol\u00e1!</p>\n    <p>Este \u00e9 seu relat\u00f3rio semanal autom\u00e1tico enviado em ${new Date().toLocaleDateString('pt-BR')}.` +\n    `</p>\n    <ul>\n      <li>Status: Ativo</li>\n      <li>Data: ${new Date().toLocaleDateString('pt-BR')}</li>\n      <li>Hor\u00e1rio: ${new Date().toLocaleTimeString('pt-BR')}</li>\n    </ul>\n    <p>Atenciosamente,<br>Sistema Automatizado</p>\n  `\n};\n\nreturn [{ json: emailData }];"
+      },
+      "id": "2b3c4d5e-6f7g-8h9i-0j1k-l2m3n4o5p6q7",
+      "name": "Preparar Dados",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        460,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBasicAuth",
+        "nodeCredentialType": "smtpApi",
+        "resource": "email",
+        "operation": "send",
+        "toEmail": "={{ $json.destinatario }}",
+        "subject": "={{ $json.assunto }}",
+        "emailFormat": "html",
+        "html": "={{ $json.corpo }}",
+        "fromEmail": "sistema@suaempresa.com",
+        "fromName": "Sistema Automatizado",
+        "options": {
+          "appendAttribution": false
+        }
+      },
+      "id": "3c4d5e6f-7g8h-9i0j-1k2l-m3n4o5p6q7r8",
+      "name": "Enviar Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2,
+      "position": [
+        680,
+        300
+      ],
+      "credentials": {
+        "smtp": {
+          "id": "smtp_credentials_id",
+          "name": "Credenciais SMTP"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "console.log('Email enviado com sucesso!');\nreturn [{ json: { status: 'sucesso', mensagem: 'Email enviado com sucesso', timestamp: new Date().toISOString(), destinatario: $input.first().json.destinatario } }];"
+      },
+      "id": "4d5e6f7g-8h9i-0j1k-2l3m-n4o5p6q7r8s9",
+      "name": "Log Resultado",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        900,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Cron Trigger": {
+      "main": [
+        [
+          {
+            "node": "Preparar Dados",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Preparar Dados": {
+      "main": [
+        [
+          {
+            "node": "Enviar Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Enviar Email": {
+      "main": [
+        [
+          {
+            "node": "Log Resultado",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "America/Sao_Paulo"
+  },
+  "meta": {
+    "instanceId": "c9aa7cfa-763c-4d59-ae33-afff84d50f68"
+  },
+  "triggerCount": 1,
+  "versionId": "1"
+}

--- a/docs/_workflows/messaging/whatsapp_assistant.json
+++ b/docs/_workflows/messaging/whatsapp_assistant.json
@@ -1,0 +1,124 @@
+{
+  "name": "WhatsApp Assistant",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "whatsapp-webhook",
+        "authentication": "basicAuth",
+        "responseMode": "responseNode",
+        "options": {
+          "ignoreBots": true
+        }
+      },
+      "id": "c9aa7cfa-763c-4d59-ae33-afff84d50f68",
+      "name": "WhatsApp Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ],
+      "credentials": {
+        "httpBasicAuth": {
+          "id": "MetaWhatsAppCreds"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "model": "gpt-4o-mini",
+        "temperature": 0.7,
+        "systemPrompt": "Você é um assistente de atendimento via WhatsApp",
+        "userPrompt": "={{$json[\"entry\"][0].changes[0].value.messages[0].text.body]}}"
+      },
+      "id": "e95f493d-f85e-4f10-8e34-7369a2b9c35b",
+      "name": "Evolution API",
+      "type": "n8n-nodes-evolution-api.evolutionApi",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ],
+      "credentials": {
+        "evolutionApi": {
+          "id": "EvolutionApiCreds"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "create",
+        "from": "whatsapp:+15551234567",
+        "to": "={{\"whatsapp:\" + $json[\"entry\"][0].changes[0].value.messages[0].from}}",
+        "text": "={{$node[\"Evolution API\"].json[\"choices\"][0].message.content}}"
+      },
+      "id": "fc5b3e57-b16f-456b-a97b-71c2cc9a38d4",
+      "name": "WhatsApp Reply",
+      "type": "n8n-nodes-base.twilio",
+      "typeVersion": 1,
+      "position": [
+        650,
+        300
+      ],
+      "credentials": {
+        "twilioApi": {
+          "id": "TwilioCreds"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "text",
+        "responseBody": "Mensagem recebida."
+      },
+      "id": "2afd7323-0c24-4678-bc9c-0ef238d1d4ee",
+      "name": "Responder",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [
+        850,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "WhatsApp Webhook": {
+      "main": [
+        [
+          {
+            "node": "Evolution API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Evolution API": {
+      "main": [
+        [
+          {
+            "node": "WhatsApp Reply",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "WhatsApp Reply": {
+      "main": [
+        [
+          {
+            "node": "Responder",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "instanceId": "cb484ba7b742928a2048bf8829668bed5b5ad9787579adea888f05980292a4a7"
+  }
+}


### PR DESCRIPTION
## Summary
- add WhatsApp assistant workflow with webhook auth and response node
- add weekly report email workflow with Cron trigger and attribution option disabled

## Testing
- `mkdocs build --config-file mkdocs-test.yml --strict` *(fails: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860473ee3508328a1fe27aefd01d2f4